### PR TITLE
Template - use ng-style instead of style

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ This especially applies to a file that has so much code that you'd need to scrol
         $scope.myPosition = 'relative'
         ...
 
-        &lt;div ng-style="{'width': myWidth+'px', 'position': myPosition}"&gt;my beautifully styled div which will work in IE&lt;/div&gt;
+        <div ng-style="{'width': myWidth+'px', 'position': myPosition}">my beautifully styled div which will work in IE</div>;
 
 #Routing
 


### PR DESCRIPTION
Using 'ng-style' instead of 'style' when assigning values of scope variables prevents IE faults
