### PR TITLE
Fixed missing backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ module.controller('MyCtrl', ['$scope', 'myFormatFilter', function ($scope, myFor
 
 #Services
 
-This section includes information about the service component in AngularJS. It is not dependent of the way of definition (i.e. as provider, `.factory`, `.service), except if explicitly mentioned.
+This section includes information about the service component in AngularJS. It is not dependent of the way of definition (i.e. as provider, `.factory`, `.service`), except if explicitly mentioned.
 
 * Use camelCase to name your services.
   * UpperCamelCase (PascalCase) for naming your services, used as constructor functions i.e.:


### PR DESCRIPTION
`.service` was missing a closing backtick character.
