### PR TITLE
Fix markdown in EN, RU, ID and IT version

### DIFF
--- a/README-id-id.md
+++ b/README-id-id.md
@@ -343,18 +343,18 @@ Bagian ini adalah informasi tentang komponen service secara umum di AngularJS da
 * Gunakan standar penamaan 'camelCase'.
   * UpperCamelCase (PascalCase) untuk nama service apabila digunakan sebagai konstruktor, seperti:
 
-```JavaScript
-module.controller('MainCtrl', function ($scope, User) {
-  $scope.user = new User('foo', 42);
-});
+    ```JavaScript
+    module.controller('MainCtrl', function ($scope, User) {
+      $scope.user = new User('foo', 42);
+    });
 
-module.factory('User', function () {
-  return function User(name, age) {
-    this.name = name;
-    this.age = age;
-  };
-});
-```
+    module.factory('User', function () {
+      return function User(name, age) {
+        this.name = name;
+        this.age = age;
+      };
+    });
+    ```
 
   * lowerCamelCase untuk semua service yang lain.
 

--- a/README-it-it.md
+++ b/README-it-it.md
@@ -409,20 +409,20 @@ non dipendono dal tipo di definizione (es: come provider, `.factory`,
 `.service`) a meno che questo non è esplicitamente menzionato.
 
 * Usare camelCase per assegnare nomi ai service:
-    * UpperCamelCase (PascalCase) per service usati come costruttori. Es:
+  * UpperCamelCase (PascalCase) per service usati come costruttori. Es:
 
-```JavaScript
-module.controller('MainCtrl', function ($scope, User) {
-  $scope.user = new User('foo', 42);
-});
+    ```JavaScript
+    module.controller('MainCtrl', function ($scope, User) {
+      $scope.user = new User('foo', 42);
+    });
 
-module.factory('User', function () {
-  return function User(name, age) {
-    this.name = name;
-    this.age = age;
-  };
-});
-```
+    module.factory('User', function () {
+      return function User(name, age) {
+        this.name = name;
+        this.age = age;
+      };
+    });
+    ```
 
   * lowerCamelCase per gli altri casi.
 

--- a/README-ru-ru.md
+++ b/README-ru-ru.md
@@ -342,18 +342,18 @@ function HomeCtrl() {
 * Используйте camelCase при определении имён сервисов.
   * UpperCamelCase (PascalCase) должен использоваться для сервисов, используемых в качестве конструкторов:
 
-```JavaScript
-module.controller('MainCtrl', function ($scope, User) {
-  $scope.user = new User('foo', 42);
-});
+    ```JavaScript
+    module.controller('MainCtrl', function ($scope, User) {
+      $scope.user = new User('foo', 42);
+    });
 
-module.factory('User', function () {
-  return function User(name, age) {
-    this.name = name;
-    this.age = age;
-  };
-});
-```
+    module.factory('User', function () {
+      return function User(name, age) {
+        this.name = name;
+        this.age = age;
+      };
+    });
+    ```
 
   * lowerCamelCase для всех остальных сервисов.
 

--- a/README.md
+++ b/README.md
@@ -342,18 +342,18 @@ This section includes information about the service component in AngularJS. It i
 * Use camelCase to name your services.
   * UpperCamelCase (PascalCase) for naming your services, used as constructor functions i.e.:
 
-```JavaScript
-module.controller('MainCtrl', function ($scope, User) {
-  $scope.user = new User('foo', 42);
-});
+    ```JavaScript
+    module.controller('MainCtrl', function ($scope, User) {
+      $scope.user = new User('foo', 42);
+    });
 
-module.factory('User', function () {
-  return function User(name, age) {
-    this.name = name;
-    this.age = age;
-  };
-});
-```
+    module.factory('User', function () {
+      return function User(name, age) {
+        this.name = name;
+        this.age = age;
+      };
+    });
+    ```
 
   * lowerCamelCase for all other services.
 


### PR DESCRIPTION
In a nested list, a fenced code block is not correctly indented, so the
following second level item is rendered as a first level item.