### PR TITLE
Change `angular.service` example to lowerCamelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,8 +559,8 @@ This section includes information about the service component in AngularJS. It i
 	  return "I'm coding";
 	};
 
-	myModule.service('Human', Human);
-	myModule.service('Developer', Developer);
+	myModule.service('human', Human);
+	myModule.service('developer', Developer);
 
 	```
 


### PR DESCRIPTION
As indicated just a couple of paragraphs above this example, one should use "lowerCamelCase for all other services" that don't return constructor functions. In this example since the constructor is being registered via `angular.service`, it will return an already-constructed instance, not a constructor function, when injected. So the name of the service should be written lowerCamelCase.