### PR TITLE
Fixed broken URLs to Google JS style guide.

### DIFF
--- a/README-de-de.md
+++ b/README-de-de.md
@@ -12,13 +12,13 @@ Sie wurden aus den folgenden Quellen zusammengestellt:
 
 Du wirst in diesem Style Guide keine allgemeinen Richtlinien für die JavaScript-Entwicklung finden. Solche finden sich unter:
 
-0. [Googles JavaScript-Style-Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Googles JavaScript-Style-Guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozillas JavaScript-Style-Guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHubs JavaScript-Style-Guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockfords JavaScript-Style-Guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript-Style-Guide](https://github.com/airbnb/javascript)
 
-Für die AngularJS-Entwicklung ist [Googles JavaScript-Style-Guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml) empfehlenswert.
+Für die AngularJS-Entwicklung ist [Googles JavaScript-Style-Guide](https://google.github.io/styleguide/javascriptguide.xml) empfehlenswert.
 
 Im GitHub-Wiki von AngularJS gibt es einen ähnlichen Abschnitt von [ProLoser](https://github.com/ProLoser), den du dir [hier](https://github.com/angular/angular.js/wiki) ansehen kannst.
 

--- a/README-es-es.md
+++ b/README-es-es.md
@@ -11,12 +11,12 @@ Estas buenas prácticas están recogidas de:
 
 En esta guía de estilo no encontrarás pautas comunes para el desarrollo en Javascript. Esas las podrás encontrar en:
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 
-Para el desarrollo de AngularJS la recomendada es [Guía de estilo de Javascript de Google](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Para el desarrollo de AngularJS la recomendada es [Guía de estilo de Javascript de Google](https://google.github.io/styleguide/javascriptguide.xml).
 
 En la wiki de Github de AngularJS hay una sección similar por [ProLoser](https://github.com/ProLoser), puedes verla [aquí](https://github.com/angular/angular.js/wiki).
 

--- a/README-fr-fr.md
+++ b/README-fr-fr.md
@@ -15,13 +15,13 @@ Elles proviennent&#8239;:
 
 Dans ce document, vous ne trouverez pas de directives générales concernant le développement en JavaScript. Vous pouvez les trouver dans les documents suivants&#8239;:
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 
-Pour le développement d'AngularJS, le guide recommandé est [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Pour le développement d'AngularJS, le guide recommandé est [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).
 
 Dans le wiki Github d'AngularJS, il y a une section similaire de [ProLoser](https://github.com/ProLoser), vous pouvez la consulter [ici](https://github.com/angular/angular.js/wiki).
 

--- a/README-id-id.md
+++ b/README-id-id.md
@@ -13,13 +13,13 @@ Cara-cara ini dikumpulkan dari:
 
 Dalam panduan ini, anda tidak akan menemukan panduan umum untuk menulis kode javascript. Seperti yang bisa anda temukan di:
 
-0. [Panduan menulis kode javascript milik Google](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Panduan menulis kode javascript milik Google](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Panduan menulis kode javascript milik Mozilla](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [Panduan menulis kode javascript milik GitHub](https://github.com/styleguide/javascript)
 0. [Panduan menulis kode javascript milik Douglas](http://javascript.crockford.com/code.html)
 0. [Panduan menulis kode javascript milik Airbnb](https://github.com/airbnb/javascript)
 
-Tapi setidaknya kami merekomendasikan anda untuk mengikuti [Panduan menulis kode javascript milik Google](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Tapi setidaknya kami merekomendasikan anda untuk mengikuti [Panduan menulis kode javascript milik Google](https://google.github.io/styleguide/javascriptguide.xml).
 
 Di halaman GitHub milik AngularJS ada sebuah wiki yang bagus seputar topik ini, kontribusi dari [ProLoser](https://github.com/ProLoser), anda bisa melihatnya di [sini](https://github.com/angular/angular.js/wiki).
 

--- a/README-it-it.md
+++ b/README-it-it.md
@@ -15,13 +15,13 @@ molto apprezzate da parte di tutti.
 In questa guida non si accennerà a comuni linee guida sulla programmazione
 JavaScript. Queste possono essere trovate nei seguenti link:
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 
-Per la programmazione AngularJS è raccomandato: [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Per la programmazione AngularJS è raccomandato: [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).
 
 Nel repository AngularJS su GitHub c'è una sezione simile curata da [ProLoser](https://github.com/ProLoser). Potete visionarla [quì](https://github.com/angular/angular.js/wiki).
 

--- a/README-ja-jp.md
+++ b/README-ja-jp.md
@@ -16,13 +16,13 @@
 
 当ガイドラインは、JavaScript開発のガイドラインではありません。JavaScript開発のガイドラインはこちらで見つけることができます：
 
-0. [Google JavaScript スタイルガイド](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google JavaScript スタイルガイド](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla JavaScript スタイルガイド](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub JavaScript スタイルガイド](https://github.com/styleguide/javascript)
 0. [Douglas Crockford JavaScript スタイルガイド](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript スタイルガイド](https://github.com/airbnb/javascript)
 
-AngularJSの開発をする上でのおすすめは[Google JavaScript スタイルガイド](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)です。
+AngularJSの開発をする上でのおすすめは[Google JavaScript スタイルガイド](https://google.github.io/styleguide/javascriptguide.xml)です。
 
 AngularJSのGitHub Wikiに[ProLoser](https://github.com/ProLoser)の書いた類似のセクションがあります。[こちら](https://github.com/angular/angular.js/wiki)で確認することができます。
 

--- a/README-ko-kr.md
+++ b/README-ko-kr.md
@@ -15,14 +15,14 @@
 
 이 스타일 가이드에서는 자바스크립트 개발 가이드라인을 제공하진 않습니다. 여기에 관련해서는 아래를 참고하세요.
 
-0. [Google 자바스크립트 스타일 가이드](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google 자바스크립트 스타일 가이드](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla 자바스크립트 스타일 가이드](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's 자바스크립트 스타일 가이드](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's 자바스크립트 스타일 가이드](http://javascript.crockford.com/code.html)
 0. [Airbnb 자바스크립트 스타일 가이드](https://github.com/airbnb/javascript)
 0. [Idiomatic 자바스크립트 스타일 가이드](https://github.com/rwaldron/idiomatic.js/)
 
-AngularJS 개발에 대해서는 [Google 자바스크립트 스타일 가이드](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)를 추천합니다.
+AngularJS 개발에 대해서는 [Google 자바스크립트 스타일 가이드](https://google.github.io/styleguide/javascriptguide.xml)를 추천합니다.
 
 AngularJS GitHub 위키에 [ProLoser](https://github.com/ProLoser)가 작성한 비슷한 항목이 있습니다. [여기](https://github.com/angular/angular.js/wiki)에서 확인할 수 있습니다.
 

--- a/README-pl-pl.md
+++ b/README-pl-pl.md
@@ -10,13 +10,13 @@ Celem tego style guide'a jest przedstawienie zbioru najlepszych praktyk i wytycz
 
 W tym style guidzie nie znajdziesz wytycznych do programowania w JavaScriptcie. Takowe znajdziesz tu:
 
-0. [Style guide'y JavaScriptu Google'a](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Style guide'y JavaScriptu Google'a](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Style guide'y JavaScriptu Mozilli](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [Style guide'y JavaScriptu GitHuba](https://github.com/styleguide/javascript)
 0. [Style guide'y JavaScriptu Douglasa Crockforda](http://javascript.crockford.com/code.html)
 0. [Style guide'y JavaScriptu AirBnB](https://github.com/airbnb/javascript)
 
-Do pisania kodu w AngularJS, zaleca się stosować do wytycznych przygotowanych przez [Google'a](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Do pisania kodu w AngularJS, zaleca się stosować do wytycznych przygotowanych przez [Google'a](https://google.github.io/styleguide/javascriptguide.xml).
 
 Na stronach wiki projektu AngularJS na Githubie, istnieje podobna sekcja przygotowana przez [ProLoser](https://github.com/ProLoser), możesz się z nią zapoznać [tu](https://github.com/angular/angular.js/wiki).
 

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -10,12 +10,12 @@ O objetivo deste guia é apresentar um conjunto de boas práticas e diretrizes p
 
 Neste guia você **não** irá encontrar diretrizes para desenvolvimento JavaScript. O que pode ser encontrado em:
 
-0. [Guia JavaScript Google](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Guia JavaScript Google](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Guia JavaScript Mozilla](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [Guia JavaScript Github](https://github.com/styleguide/javascript)
 0. [Guia JavaScript Douglas Crockford](http://javascript.crockford.com/code.html)
 
-Para o desenvolvimento usando o AngularJS é recomendado o [Guia JavaScript Google](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Para o desenvolvimento usando o AngularJS é recomendado o [Guia JavaScript Google](https://google.github.io/styleguide/javascriptguide.xml).
 
 Na wiki do AngularJS no Github temos uma seção similar feita pelo [ProLoser](https://github.com/ProLoser), você pode vê-la [aqui](https://github.com/angular/angular.js/wiki).
 

--- a/README-ru-ru.md
+++ b/README-ru-ru.md
@@ -16,13 +16,13 @@
 
 В данном руководстве вы не найдете общих требований к стилю для разработки на JavaScript. Они есть тут:
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 
-При разработке приложений на AngularJS рекомендуется использовать [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+При разработке приложений на AngularJS рекомендуется использовать [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).
 
 На wiki странице GitHub репозитория AngularJS есть похожая секция, созданная [ProLoser](https://github.com/ProLoser), которая находится [здесь](https://github.com/angular/angular.js/wiki).
 

--- a/README-sr-lat.md
+++ b/README-sr-lat.md
@@ -11,12 +11,12 @@ Ove najbolje prakse su prikupljene od:
 
 U ovom vodiču nećete naći uobičajene preporuke za JavaScript programiranje. Takve se mogu naći na:
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 
-Za AngularJS razvoj preporučen je [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+Za AngularJS razvoj preporučen je [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).
 
 Na AngularJS's GitHub wiki-u postoji slična sekcija od [ProLoser](https://github.com/ProLoser), možete je naći na [here](https://github.com/angular/angular.js/wiki).
 

--- a/README-sr.md
+++ b/README-sr.md
@@ -11,12 +11,12 @@
 
 У овом водичу нећете наћи уобичајене препоруке за JavaScript програмирање. Такве се могу наћи на:
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 
-За AngularJS развој препоручен је [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+За AngularJS развој препоручен је [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).
 
 На AngularJS's GitHub wiki-у постоји слична секција од [ProLoser](https://github.com/ProLoser), možete je naći na [here](https://github.com/angular/angular.js/wiki).
 

--- a/README-tr-tr.md
+++ b/README-tr-tr.md
@@ -15,13 +15,13 @@ En iyi kullanışlar:
 
 Bu dökümanda genel Javascript geliştirmelerinin ortak kullanımını göremeyeceksiniz. Genel olarak kullanımlar aşağıdadır:
 
-0. [Google's JavaScript dökümanı](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript dökümanı](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript dökümanı](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript dökümanı](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript dökümanı](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript dökümanı](https://github.com/airbnb/javascript)
 
-AngularJs geliştirmeleri için [Google's JavaScript dökümanı](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+AngularJs geliştirmeleri için [Google's JavaScript dökümanı](https://google.github.io/styleguide/javascriptguide.xml).
 
  AngularJS Github dökümanı için [ProLoser](https://github.com/ProLoser), buradan kontrol edebilirsin [here](https://github.com/angular/angular.js/wiki).
 

--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -12,13 +12,13 @@
 
 在本指南中不会包含基本的JavaScript开发指南。这些基本的指南可以在下面的列表中找到：
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 
-对于AngularJS开发，推荐 [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+对于AngularJS开发，推荐 [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).
 
 在AngularJS的Github wiki中有一个相似的章节 [ProLoser](https://github.com/ProLoser), 你可以点击[这里](https://github.com/angular/angular.js/wiki)查看。
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ These best practices are collected from:
 
 In this style guide you won't find common guidelines for JavaScript development. Such can be found at:
 
-0. [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)
+0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
 0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 0. [Idiomatic JavaScript style guide](https://github.com/rwaldron/idiomatic.js/)
 
-For AngularJS development recommended is the [Google's JavaScript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+For AngularJS development recommended is the [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).
 
 In AngularJS's GitHub wiki there is a similar section by [ProLoser](https://github.com/ProLoser), you can check it [here](https://github.com/angular/angular.js/wiki).
 


### PR DESCRIPTION
Google changed the URL of their JS style guide to https://google.github.io/styleguide/javascriptguide.xml. I updated all README file links to the new URL.