### PR TITLE
Removed broken URL to GitHub JS Style Guide

### DIFF
--- a/README-de-de.md
+++ b/README-de-de.md
@@ -14,7 +14,6 @@ Du wirst in diesem Style Guide keine allgemeinen Richtlinien für die JavaScript
 
 0. [Googles JavaScript-Style-Guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozillas JavaScript-Style-Guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHubs JavaScript-Style-Guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockfords JavaScript-Style-Guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript-Style-Guide](https://github.com/airbnb/javascript)
 
@@ -207,7 +206,7 @@ Die Namensgebung für alle Elemente sind in folgender Tabelle wieder zu finden:
 Element | Style | Beispiel | Verwendung bei
 ----|------|----|--------
 Module | lowerCamelCase  | angularApp |
-Controller | funktionalität + 'Ctrl'  | adminCtrl | 
+Controller | funktionalität + 'Ctrl'  | adminCtrl |
 Direktiven | lowerCamelCase  | userInfo |
 Filter | lowerCamelCase | userFilter |
 Services | UpperCamelCase | User | Konstruktor

--- a/README-es-es.md
+++ b/README-es-es.md
@@ -13,7 +13,6 @@ En esta guía de estilo no encontrarás pautas comunes para el desarrollo en Jav
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 
 Para el desarrollo de AngularJS la recomendada es [Guía de estilo de Javascript de Google](https://google.github.io/styleguide/javascriptguide.xml).

--- a/README-fr-fr.md
+++ b/README-fr-fr.md
@@ -17,7 +17,6 @@ Dans ce document, vous ne trouverez pas de directives générales concernant le 
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 
@@ -543,4 +542,3 @@ TBD
 #Contribution
 
 Puisque ce guide de style a pour but d'être un projet communautaire, les contributions sont très appréciées. Par exemple, vous pouvez contribuer en développant la section [Tests](#tests) ou en traduisant le guide dans votre langue.
-

--- a/README-id-id.md
+++ b/README-id-id.md
@@ -15,7 +15,6 @@ Dalam panduan ini, anda tidak akan menemukan panduan umum untuk menulis kode jav
 
 0. [Panduan menulis kode javascript milik Google](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Panduan menulis kode javascript milik Mozilla](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [Panduan menulis kode javascript milik GitHub](https://github.com/styleguide/javascript)
 0. [Panduan menulis kode javascript milik Douglas](http://javascript.crockford.com/code.html)
 0. [Panduan menulis kode javascript milik Airbnb](https://github.com/airbnb/javascript)
 
@@ -123,7 +122,7 @@ Dengan cara ini, struktur akan terlihat seperti ini:
 └── test
 ```
 
-**Struktur tambahan:** Ketika membuat directives, akan sangat memudahkan apabila anda menempatkan semua file yang berhubungan (seperti: templates, CSS/SASS) di dalam direktori yang sama. Jika anda mengikuti cara ini, anda harus konsisten. 
+**Struktur tambahan:** Ketika membuat directives, akan sangat memudahkan apabila anda menempatkan semua file yang berhubungan (seperti: templates, CSS/SASS) di dalam direktori yang sama. Jika anda mengikuti cara ini, anda harus konsisten.
 
 ```
 app

--- a/README-it-it.md
+++ b/README-it-it.md
@@ -17,7 +17,6 @@ JavaScript. Queste possono essere trovate nei seguenti link:
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 

--- a/README-ja-jp.md
+++ b/README-ja-jp.md
@@ -18,7 +18,6 @@
 
 0. [Google JavaScript スタイルガイド](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla JavaScript スタイルガイド](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub JavaScript スタイルガイド](https://github.com/styleguide/javascript)
 0. [Douglas Crockford JavaScript スタイルガイド](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript スタイルガイド](https://github.com/airbnb/javascript)
 

--- a/README-ko-kr.md
+++ b/README-ko-kr.md
@@ -17,7 +17,6 @@
 
 0. [Google 자바스크립트 스타일 가이드](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla 자바스크립트 스타일 가이드](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's 자바스크립트 스타일 가이드](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's 자바스크립트 스타일 가이드](http://javascript.crockford.com/code.html)
 0. [Airbnb 자바스크립트 스타일 가이드](https://github.com/airbnb/javascript)
 0. [Idiomatic 자바스크립트 스타일 가이드](https://github.com/rwaldron/idiomatic.js/)
@@ -525,7 +524,7 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
 
 * 서비스명은 camelCase나 CamelCase로 작성합니다.
 	* 생성자 함수인 서비스의 이름은 다음과 같이 UpperCamelCase (PascalCase)를 사용합니다.
-    
+
     ```JavaScript
     function MainCtrl($scope, User) {
       $scope.user = new User('foo', 42);
@@ -725,4 +724,3 @@ $scope.divStyle = {
 [<img alt="giantray" src="https://avatars.githubusercontent.com/u/5054377?v=3&s=117" width="117">](https://github.com/giantray) |[<img alt="ntaoo" src="https://avatars.githubusercontent.com/u/511213?v=3&s=117" width="117">](https://github.com/ntaoo) |[<img alt="kuzmeig1" src="https://avatars.githubusercontent.com/u/8707951?v=3&s=117" width="117">](https://github.com/kuzmeig1) |
 :---: |:---: |:---: |
 [giantray](https://github.com/giantray) |[ntaoo](https://github.com/ntaoo) |[kuzmeig1](https://github.com/kuzmeig1) |
-

--- a/README-pl-pl.md
+++ b/README-pl-pl.md
@@ -12,7 +12,6 @@ W tym style guidzie nie znajdziesz wytycznych do programowania w JavaScriptcie. 
 
 0. [Style guide'y JavaScriptu Google'a](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Style guide'y JavaScriptu Mozilli](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [Style guide'y JavaScriptu GitHuba](https://github.com/styleguide/javascript)
 0. [Style guide'y JavaScriptu Douglasa Crockforda](http://javascript.crockford.com/code.html)
 0. [Style guide'y JavaScriptu AirBnB](https://github.com/airbnb/javascript)
 

--- a/README-pt-br.md
+++ b/README-pt-br.md
@@ -12,7 +12,6 @@ Neste guia você **não** irá encontrar diretrizes para desenvolvimento JavaScr
 
 0. [Guia JavaScript Google](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Guia JavaScript Mozilla](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [Guia JavaScript Github](https://github.com/styleguide/javascript)
 0. [Guia JavaScript Douglas Crockford](http://javascript.crockford.com/code.html)
 
 Para o desenvolvimento usando o AngularJS é recomendado o [Guia JavaScript Google](https://google.github.io/styleguide/javascriptguide.xml).

--- a/README-ru-ru.md
+++ b/README-ru-ru.md
@@ -18,7 +18,6 @@
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 
@@ -259,7 +258,7 @@ services
     - Потере производительности, потому что интерпретатор написан на JavaScript
     - Ненужному кешированию обработанных выражений внутри сервиса `$parse`, потому что в подавляющем большинстве случаев выражения, прописанные в `ngInit`, используются только один раз
     - Большему риску появления ошибок - вы пишете код, как текстовую строку шаблона, соответственно нет подсветки синтаксиса и других плюшек вашего любимого редактора/IDE
-    - Невозможности перехватывать run-time ошибки - они просто не будут брошены. 
+    - Невозможности перехватывать run-time ошибки - они просто не будут брошены.
 * Не используйте префикс `$` при определении переменных, свойств и методов. Этот префикс зарезервирован для AngularJS.
 * При перечислении зависимостей сперва указывайте встроенные, потом дополнительные:
 
@@ -273,7 +272,7 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
 
 # <a name="modules"></a>Модули
 
-* Названия модулей должны соответстовать подходу lowerCamelCase. Для определения иерархии, например, что модуль `b` является подмодулем `a`, используйте пространства имён: `a.b`. 
+* Названия модулей должны соответстовать подходу lowerCamelCase. Для определения иерархии, например, что модуль `b` является подмодулем `a`, используйте пространства имён: `a.b`.
 
 Существует два основных способа структурирования модулей:
 
@@ -284,7 +283,7 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
 
 # <a name="controllers"></a>Контроллеры
 * Не изменяйте DOM из контроллеров, это усложнит их тестирование, а также нарушит [Принцип разделения ответственности](https://en.wikipedia.org/wiki/Separation_of_concerns). Используйте для этого директивы.
-* Именовать контроллер следует так, чтобы его имя состояло из части, описывающей то, чем он занимается (для примера: корзина, домашняя страница, админ-панель) и постфикса `Ctrl`. 
+* Именовать контроллер следует так, чтобы его имя состояло из части, описывающей то, чем он занимается (для примера: корзина, домашняя страница, админ-панель) и постфикса `Ctrl`.
 * Контроллеры - это стандартные [конструкторы](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor), соответвенно их имена записываются в UpperCamelCase (`HomePageCtrl`, `ShoppingCartCtrl`, `AdminPanelCtrl`, и т.д.).
 * Контроллеры не должны быть объявлены в глобальном пространстве (хотя AngularJS и позволяет использовать этот подход, он засоряет глобальное пространство имён, а потому считается нежелательным).
 * Используйте следующий синтаксис для объявления контроллеров:
@@ -295,7 +294,7 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
    }
    module.controller('MyCtrl', MyCtrl);
    ```
-   
+
 
 Чтобы избежать проблем с минификацией файлов, вы можете автоматически генерировать определение с синтаксисом массива, используя инструменты типа [ng-annotate](https://github.com/olov/ng-annotate) (и задачи для grunt [grunt-ng-annotate](https://github.com/mzgol/grunt-ng-annotate)).
 
@@ -306,15 +305,15 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
     {{ main.title }}
   </div>
   ```
-  
+
   ```JavaScript
   app.controller('MainCtrl', MainCtrl);
-  
+
   function MainCtrl () {
     this.title = 'Some title';
   };
   ```
-   
+
    Основные плюшки:
    * Создаётся 'изолированный' компонент - привязанные свойства не являются частью цепочки прототипов `$scope`. Это хороший подход, поскольку наследование прототипов `$scope` имеет серьёзные недостатки (вероятно, именно поэтому это было выкинуто из Angular 2):
       * Тяжело отследить, откуда к нам пришли данные.
@@ -323,7 +322,7 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
       * '[Правило точки](http://jimhoskins.com/2012/12/14/nested-scopes-in-angularjs.html)'.
    * `$scope` не используется, если нам не нужны специфичные операции (типа `$scope.$broadcast`). Это хорошая подготовка к AngularJS V2.
    * Синтаксис значительно ближе к 'ванильному' конструктору JavaScript
-   
+
    Больше о подходе `controller as` здесь: [digging-into-angulars-controller-as-syntax](http://toddmotto.com/digging-into-angulars-controller-as-syntax/)
 
 * При использовании синтаксиса массива используйте оригинальные имена для зависимостей контроллера. Код будет более читабельным:
@@ -332,7 +331,7 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
   function MyCtrl(s) {
    // ...
   }
-  
+
   module.controller('MyCtrl', ['$scope', MyCtrl]);
   ```
 
@@ -406,7 +405,7 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
 * Создайте и поддерживайте список со всеми сообщениями пересылаемыми с помощью `$emit`, `$broadcast`, чтобы избежать коллизий имён и прочих возможных ошибок.
 
   Пример:
-  
+
   ```JavaScript
   // app.js
   /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -418,9 +417,9 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
        - action - specific ation the user tries to perform
   * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
   ```
-  
+
   * Если вам нужно отформатировать данные, перенесите логику форматирования в [фильтр](#filters) и укажите его как зависимость:
-  
+
   ```JavaScript
   function myFormat() {
    return function () {
@@ -428,11 +427,11 @@ module.factory('Service', function ($rootScope, $timeout, MyCustomDependency1, M
    };
   }
   module.filter('myFormat', myFormat);
-  
+
   function MyCtrl($scope, myFormatFilter) {
    // ...
   }
-  
+
   module.controller('MyCtrl', MyCtrl);
   ```
 
@@ -489,14 +488,14 @@ function HomeCtrl() {
         function MainCtrl($scope, User) {
           $scope.user = new User('foo', 42);
         }
-    
+
         module.controller('MainCtrl', MainCtrl);
-    
+
         function User(name, age) {
           this.name = name;
           this.age = age;
         }
-    
+
         module.factory('User', function () {
           return User;
         });
@@ -545,7 +544,7 @@ function HomeCtrl() {
 	Human.prototype.talk = function () {
 	  return "I'm talking";
 	};
-	
+
 	function Developer() {
 	  //body
 	}
@@ -553,10 +552,10 @@ function HomeCtrl() {
 	Developer.prototype.code = function () {
 	  return "I'm coding";
 	};
-	
+
 	myModule.service('Human', Human);
 	myModule.service('Developer', Developer);
-	
+
 	```
 * Для кеширования на уровне сессии можно использовать `$cacheFactory`. Этот метод подходит для кеширования результатов сложных вычислений или каких-либо запросов.
 * Если сервис нуждается в настройке при старте приложения, определяйте его через `provider`, а затем конфигурируйте через коллбек `config`:
@@ -633,8 +632,8 @@ $scope.divStyle = {
     ```
     После этого, для `main.things` не будет создано **ни одного** watch и любые дальнейшие изменения `main.things` не будет отражены на странице.
   * Сделайте вычисления в `$watch` максимально простыми. Любые сложные и медленные вычисления в `$watch` замедляют выполнение всего приложения (цикл `$digest` работает в одном потоке, потому что JavaScript однопоточный).
-  * При отслеживании коллекций с помощью `$watch` используйте глубокое отслеживание только если это действительно необходимо. Обычно достаточно использовать `$watchCollection`, который выполняет простую проверку свойств только первого уровня наблюдаемого объекта. 
-  * При вызове функции `$timeout` устанавливайте третий параметр в false, если функция обратного вызова не изменяет отслеживаемые переменные. В этом случае `$digest` не будет вызван после выполнения функции. 
+  * При отслеживании коллекций с помощью `$watch` используйте глубокое отслеживание только если это действительно необходимо. Обычно достаточно использовать `$watchCollection`, который выполняет простую проверку свойств только первого уровня наблюдаемого объекта.
+  * При вызове функции `$timeout` устанавливайте третий параметр в false, если функция обратного вызова не изменяет отслеживаемые переменные. В этом случае `$digest` не будет вызван после выполнения функции.
   * При работе с редко изменяемыми большими коллекциями, [используйте неизменяемые структуры данных](http://blog.mgechev.com/2015/03/02/immutability-in-angularjs-immutablejs).
 
 * Не забывайте про способы уменьшения количества запросов к серверу. Одним из них является объединение/кеширование шаблонов в один файл, к примеру используя [grunt-html2js](https://github.com/karlgoldstein/grunt-html2js) / [gulp-html2js](https://github.com/fraserxu/gulp-html2js). [Здесь](http://ng-learn.org/2014/08/Populating_template_cache_with_html2js/) и [здесь](http://slides.com/yanivefraim-1/real-world-angularjs#/34) есть подробная информация. Эффект особенно ощутим, если проект содержит много отдельных файлов шаблонов небольшого размера.

--- a/README-sr-lat.md
+++ b/README-sr-lat.md
@@ -4,7 +4,7 @@ Cilj ovog "style guide" vodiča je da predstavi set najboljih praksi i smernica 
 Ove najbolje prakse su prikupljene od:
 
 0. AngularJS izvornog koda
-0. Izvornog koda ili članaka koje sam pročitao 
+0. Izvornog koda ili članaka koje sam pročitao
 0. Ličnog iskustva
 
 **Nota**: ovo je još uvek radna verzija, njen glavni cilj je da bude "community-driven" zato ispunjavanje praznina će biti veoma cenjeno od strane cele zajednice.
@@ -13,7 +13,6 @@ U ovom vodiču nećete naći uobičajene preporuke za JavaScript programiranje. 
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 
 Za AngularJS razvoj preporučen je [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).

--- a/README-sr.md
+++ b/README-sr.md
@@ -4,7 +4,7 @@
 Ове најбоље праксе су прикупљене од:
 
 0. AngularJS ижворног кода
-0. Изворног кода или чланака које сам прочитао 
+0. Изворног кода или чланака које сам прочитао
 0. Личног искуства
 
 **Нота**: ово је још увек радна верзија, њен главни циљ је да буде "community-driven" зато ће испуњавање празнина бити веома цењено од стране целе заједнице.
@@ -13,7 +13,6 @@
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 
 За AngularJS развој препоручен је [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).

--- a/README-tr-tr.md
+++ b/README-tr-tr.md
@@ -17,7 +17,6 @@ Bu dökümanda genel Javascript geliştirmelerinin ortak kullanımını göremey
 
 0. [Google's JavaScript dökümanı](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript dökümanı](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript dökümanı](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript dökümanı](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript dökümanı](https://github.com/airbnb/javascript)
 
@@ -521,4 +520,3 @@ $scope.divStyle = {
 [<img alt="gokhan" src="https://avatars0.githubusercontent.com/u/6371971?v=3&s=460" width="117">](https://github.com/previousdeveloper) |
 :---: |
 [gokhan](https://github.com/previousdeveloper) |
-

--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -14,7 +14,6 @@
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 
@@ -689,4 +688,3 @@ $scope.divStyle = {
 [<img alt="ntaoo" src="https://avatars.githubusercontent.com/u/511213?v=3&s=117" width="117">](https://github.com/ntaoo) |[<img alt="kuzmeig1" src="https://avatars.githubusercontent.com/u/8707951?v=3&s=117" width="117">](https://github.com/kuzmeig1) |
 :---: |:---: |
 [ntaoo](https://github.com/ntaoo) |[kuzmeig1](https://github.com/kuzmeig1) |
-

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ In this style guide you won't find common guidelines for JavaScript development.
 
 0. [Google's JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml)
 0. [Mozilla's JavaScript style guide](https://developer.mozilla.org/en-US/docs/Developer_Guide/Coding_Style)
-0. [GitHub's JavaScript style guide](https://github.com/styleguide/javascript)
 0. [Douglas Crockford's JavaScript style guide](http://javascript.crockford.com/code.html)
 0. [Airbnb JavaScript style guide](https://github.com/airbnb/javascript)
 0. [Idiomatic JavaScript style guide](https://github.com/rwaldron/idiomatic.js/)
@@ -846,5 +845,3 @@ For example, you can contribute by extending the Testing section or by translati
 [<img alt="dominickolbe" src="https://avatars.githubusercontent.com/u/6094725?v=3&s=117" width="117">](https://github.com/dominickolbe) |
 :---: |
 [dominickolbe](https://github.com/dominickolbe) |
-
-


### PR DESCRIPTION
The GitHub JS Style Guide do not exist anymore.